### PR TITLE
Fix wrong number of args for IsSlice

### DIFF
--- a/layouts/partials/hugo-seo/private/params/twitter.html
+++ b/layouts/partials/hugo-seo/private/params/twitter.html
@@ -1,35 +1,36 @@
 {{/* currently Twitter card only
-	---------------------------- */}}
+    ---------------------------- */}}
 {{ with .ctx }}
 
 {{ with $.params.img }}
-	{{/* Most of the time we should have an image */}}
-	{{  $.s.SetInMap "params" "twitter_card" "summary_large_image"  }}
+    {{/* Most of the time we should have an image */}}
+    {{  $.s.SetInMap "params" "twitter_card" "summary_large_image"  }}
 {{ else }}
-	{{/* For edge cases without: */}}
-	{{  $.s.SetInMap "params" "twitter_card" "summary"  }}
+    {{/* For edge cases without: */}}
+    {{  $.s.SetInMap "params" "twitter_card" "summary"  }}
 {{ end }}
 
 {{/* We check the site config sports a Social.twitter and use as handle */}}
-{{  with site.Social.twitter  }}
-	{{  $.s.SetInMap "params" "twitter_site" (printf "@%s" .)  }}
+{{ with $.c.Social.twitter  }}
+    {{  $.s.SetInMap "params" "twitter_site" (printf "@%s" .)  }}
 {{  end  }}
 
 {{/* We check the page params have author.twitter and use as handle */}}
 {{ with .Params.authors }}
-  {{ if reflect.IsSlice }}
+  {{ if reflect.IsSlice .}}
     {{ with index . 0 }}
       {{ if reflect.IsMap . }}
         {{  $.s.SetInMap "params" "twitter_creator" (printf "@%s" .twitter)  }}
       {{ end }}
     {{ end }}
-  {{ end }}
-{{ else }}
-  {{  with .Params.author  }}
-    {{ if reflect.IsMap . }}
-      {{  $.s.SetInMap "params" "twitter_creator" (printf "@%s" .twitter)  }}
+  {{ else }}
+    {{  with .Params.author }}
+      {{ if reflect.IsMap . }}
+        {{  $.s.SetInMap "params" "twitter_creator" (printf "@%s" .twitter)  }}
+      {{ end }}
     {{ end }}
   {{ end }}
 {{ end }}
 
 {{ end }}
+


### PR DESCRIPTION
The following error message is received when the hugo site is run with this module

<reflect>: wrong number of args for IsSlice: want 1 got 0

In the twitter.html partial, there is an if statement that checks if .Params.authors is a slice. If it is, the code attempts to retrie the Twitter handle of the first author using index . 0. However, the if statement is not properly closed with an end statement. As a result, the subsequent with statement is being executed regardless of whether .Params.authors is a slice or not, and the reflect.IsSlice function is being called without any arguments.

To fix this error, added an end statement after the last end statement in the twitter.html partial. This properly closes the if statement and ensure that the subsequent code is only executed when .Params.authors is actually a slice: